### PR TITLE
add install destinations, fix cmake errors

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ set_target_properties(geohash_dynamic
 
 install( TARGETS geohash_dynamic
    LIBRARY DESTINATION lib
+   PUBLIC_HEADER DESTINATION include
    )
 
 # Static library
@@ -34,6 +35,7 @@ set_target_properties(geohash_static
 
 install( TARGETS geohash_static
    ARCHIVE DESTINATION lib
+   LIBRARY DESTINATION lib
    PUBLIC_HEADER DESTINATION include
    )
 


### PR DESCRIPTION

error:
```
~/studies/libgeohash [master*] cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release
-- The C compiler identification is GNU 4.9.1
-- The CXX compiler identification is GNU 4.9.1
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
INSTALL TARGETS - target geohash_dynamic has PUBLIC_HEADER files but no PUBLIC_HEADER DESTINATION.
CMake Error at src/CMakeLists.txt:35 (install):
  install TARGETS given no LIBRARY DESTINATION for shared library target
  "geohash_static".


-- Check for CUnit
-- Check for CUnit -- ok
-- Configuring incomplete, errors occurred!
```
```
~/studies/libgeohash [master*] cmake --version
cmake version 2.8.12.2
```
now fixed
```
~/studies/libgeohash [master*] cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release
-- Check for CUnit
-- Check for CUnit -- ok
-- Configuring done
-- Generating done
-- Build files have been written to: /home/leite/studies/libgeohash
```