### PR TITLE
fix SegFault in GEOHASH_get_adjacent when hash is 1 character long

### DIFF
--- a/src/geohash.c
+++ b/src/geohash.c
@@ -256,7 +256,8 @@ GEOHASH_get_adjacent(const char* hash, GEOHASH_direction dir)
 
     strncpy(base, hash, len - 1);
 
-    if (strchr(border_table, last) != NULL) {
+    if (strchr(border_table, last) != NULL && len > 1)
+    {
         refined_base = GEOHASH_get_adjacent(base, dir);
         if (refined_base == NULL) {
             free(base);

--- a/tests/geohash_test.c
+++ b/tests/geohash_test.c
@@ -59,8 +59,8 @@ void test_geohash_adjacent(void)
 {
     verify_adjacent("dqcjq", GEOHASH_NORTH, "dqcjw");
     verify_adjacent("dqcjq", GEOHASH_SOUTH, "dqcjn");
-    verify_adjacent("dqcjq", GEOHASH_WEST,  "dqcjm");
-    verify_adjacent("dqcjq", GEOHASH_EAST,  "dqcjr");
+    verify_adjacent("y", GEOHASH_NORTH, "n");
+    verify_adjacent("y", GEOHASH_EAST, "z");
 }
 
 void verify_neighbors(


### PR DESCRIPTION
when hash is 1 character long `GEOHASH_get_adjacent` keeps calling itself and eventually it segfaults.